### PR TITLE
consolidate game.numPlayers and game.activePlayerIndex -> game.turnCount

### DIFF
--- a/game/components/Game/index.js
+++ b/game/components/Game/index.js
@@ -19,8 +19,16 @@ class Game {
         return this._store.getState().game.status;
     }
 
+    get turnCount() {
+        return this._store.getState().game.turnCount;
+    }
+
     get activePlayerIndex() {
-        return this._store.getState().game.activePlayerIndex;
+        return this.turnCount % this._board.players.length;
+    }
+
+    get activePlayer() {
+        return this._board.players[this.activePlayerIndex];
     }
 
     get numMovesRemaining() {
@@ -64,7 +72,7 @@ class Game {
             return;
         }
 
-        if (this._board.players[this.activePlayerIndex].id !== move.player.id) {
+        if (this.activePlayer.id !== move.player.id) {
             return;
         }
 
@@ -73,8 +81,8 @@ class Game {
             this._store.dispatch(spendMove());
 
             if (this.numMovesRemaining <= 0) {
-                const hand = this._board._deck.draw(settings.NUM_CARDS_DRAWN_PER_TURN);
-                this._store.dispatch(givePlayerCards(hand, this._board.players[this.activePlayerIndex].id));
+                const cards = this._board._deck.draw(settings.NUM_CARDS_DRAWN_PER_TURN);
+                this._store.dispatch(givePlayerCards(cards, this.activePlayer.id));
                 this._store.dispatch(cycleToNextPlayer());
             }
         } else {

--- a/game/reducers/game/index.js
+++ b/game/reducers/game/index.js
@@ -6,24 +6,17 @@ import {
     GAME_SPEND_MOVE,
     GAME_CYCLE_TO_NEXT_PLAYER
 } from '../../constants/game';
-import { PLAYERS_REGISTER_PLAYER } from '../../constants/players';
 import settings from '../../config/settings'
 
 const initialState = {
     status: GAME_STATUS_INIT,
-    numPlayers: 0,
-    activePlayerIndex: 0,
+    turnCount: 0,
     numMovesRemaining: settings.NUM_PLAYER_MOVES_PER_TURN,
     err: null
 };
 
 export default function game(state=initialState, action) {
     switch (action.type) {
-        case PLAYERS_REGISTER_PLAYER:
-            return {
-                ...state,
-                numPlayers: state.numPlayers + 1
-            };
         case GAME_START:
             return {
                 ...state,
@@ -37,7 +30,7 @@ export default function game(state=initialState, action) {
         case GAME_CYCLE_TO_NEXT_PLAYER:
             return {
                 ...state,
-                activePlayerIndex: (state.activePlayerIndex + 1) % state.numPlayers,
+                turnCount: state.turnCount + 1,
                 numMovesRemaining: settings.NUM_PLAYER_MOVES_PER_TURN
             };
         default:

--- a/game/tests/game.test.js
+++ b/game/tests/game.test.js
@@ -48,6 +48,6 @@ test('ValidParenthesesGame runs correctly', () => {
         }
     }
 
-    expect(game._store.getState().game.activePlayerIndex).toBe(1);
-    expect(game._store.getState().game.numMovesRemaining).toBe(4);
+    expect(game.activePlayerIndex).toBe(1);
+    expect(game.numMovesRemaining).toBe(4);
 });


### PR DESCRIPTION
this PR is just to clean up some code. the game part of the state tree really shouldn't be keeping track of the number of players, but it needs to know that in order to calculate the activePlayerIndex (which it should be keeping track of). this PR solves that by just keeping track of the number of turns, since if we know how many turns have passed we can then know which player is supposed to be active. we can then move logic to determine active player into the Game object itself, rather than doing it some messy mod operation in the reducer